### PR TITLE
Only perform Kapt wiring if the anvilMigrationReport task is requested

### DIFF
--- a/can-i-use-anvil-plugin/src/main/kotlin/com/toasttab/canv/gradle/AnvilMigrationReportPlugin.kt
+++ b/can-i-use-anvil-plugin/src/main/kotlin/com/toasttab/canv/gradle/AnvilMigrationReportPlugin.kt
@@ -35,28 +35,30 @@ class AnvilMigrationReportPlugin : Plugin<Project> {
             output = project.layout.buildDirectory.file("anvil-aggregated-report.json").get().asFile
         }
 
-        root.allprojects.forEach { sub ->
-            sub.afterEvaluate {
-                configurations.kapt {
-                    if (it.hasDagger()) {
-                        val output = layout.buildDirectory.file("anvil-report.json").get().asFile
+        if (root.gradle.startParameter.taskNames.contains("anvilMigrationReport")) {
+            root.allprojects.forEach { sub ->
+                sub.afterEvaluate {
+                    configurations.kapt {
+                        if (it.hasDagger()) {
+                            val output = layout.buildDirectory.file("anvil-report.json").get().asFile
 
-                        configure<KaptExtension> {
-                            arguments {
-                                arg("anvil.migration.project", sub.name)
-                                arg("anvil.migration.report", "file://$output")
+                            configure<KaptExtension> {
+                                arguments {
+                                    arg("anvil.migration.project", sub.name)
+                                    arg("anvil.migration.report", "file://$output")
+                                }
                             }
-                        }
 
-                        tasks.withType<KaptTask> {
-                            if (extension.matches(name)) {
-                                outputs.file(output).withPropertyName("anvil-report-output")
+                            tasks.withType<KaptTask> {
+                                if (extension.matches(name)) {
+                                    outputs.file(output).withPropertyName("anvil-report-output")
 
-                                addReportTask(rootReportTask, output, this)
+                                    addReportTask(rootReportTask, output, this)
+                                }
                             }
-                        }
 
-                        it.addDependency("com.toasttab.canv:can-i-use-anvil-processor:${BuildConfig.VERSION}")
+                            it.addDependency("com.toasttab.canv:can-i-use-anvil-processor:${BuildConfig.VERSION}")
+                        }
                     }
                 }
             }

--- a/can-i-use-anvil-plugin/src/main/kotlin/com/toasttab/canv/gradle/AnvilMigrationRootReportTask.kt
+++ b/can-i-use-anvil-plugin/src/main/kotlin/com/toasttab/canv/gradle/AnvilMigrationRootReportTask.kt
@@ -34,9 +34,14 @@ abstract class AnvilMigrationRootReportTask : DefaultTask() {
     @TaskAction
     fun execute() {
         val report = AggregatedAnvilMigrationReport(
-            reports.map {
-                AnvilMigrationReport.decodeFromString(it.readText())
-            },
+            reports.mapNotNull {
+                if (it.exists()) {
+                    AnvilMigrationReport.decodeFromString(it.readText())
+                } else {
+                    logger.warn("report $it does not exist, possibly project has no sources")
+                    null
+                }
+            }
         )
 
         output.writeText(report.encodeToString())

--- a/can-i-use-anvil-plugin/src/test/kotlin/com/toasttab/canv/gradle/AnvilMigrationReportPluginIntegrationTest.kt
+++ b/can-i-use-anvil-plugin/src/test/kotlin/com/toasttab/canv/gradle/AnvilMigrationReportPluginIntegrationTest.kt
@@ -32,7 +32,7 @@ class AnvilMigrationReportPluginIntegrationTest {
     @Test
     fun `processor dependency added to the kapt configuration when using dagger`(project: TestProject) {
         val result = project.createRunner()
-            .withArguments("dependencies", "--configuration=kapt")
+            .withArguments("anvilMigrationReport", "dependencies", "--configuration=kapt")
             .build()
 
         expectThat(result.output).contains(
@@ -43,7 +43,7 @@ class AnvilMigrationReportPluginIntegrationTest {
     @Test
     fun `processor dependency not added to the kapt configuration when not using dagger`(project: TestProject) {
         val result = project.createRunner()
-            .withArguments("dependencies", "--configuration=kapt")
+            .withArguments("anvilMigrationReport", "dependencies", "--configuration=kapt")
             .build()
 
         expectThat(result.output).not().contains(
@@ -54,7 +54,7 @@ class AnvilMigrationReportPluginIntegrationTest {
     @Test
     fun `processor dependency not added without kapt`(project: TestProject) {
         val result = project.createRunner()
-            .withArguments("dependencies")
+            .withArguments("anvilMigrationReport", "dependencies")
             .build()
 
         expectThat(result.output).not().contains(

--- a/can-i-use-anvil-plugin/src/test/projects/AnvilMigrationReportPluginIntegrationTest/processor dependency added to the kapt configuration when using dagger/build.gradle.kts
+++ b/can-i-use-anvil-plugin/src/test/projects/AnvilMigrationReportPluginIntegrationTest/processor dependency added to the kapt configuration when using dagger/build.gradle.kts
@@ -5,6 +5,28 @@ plugins {
     id("com.toasttab.testkit.coverage") version "@TESTKIT_PLUGIN_VERSION@"
 }
 
+repositories {
+    // use the ivy repository trick to point kapt to the processor uberjar
+    // the uberjar is only necessary for tests because we are not doing any proper dependency resolution here
+    ivy {
+        url = uri("@PROCESSOR_LIBS@")
+
+        patternLayout {
+            artifact("[module]-[revision]-all.[ext]")
+        }
+
+        metadataSources {
+            artifact()
+        }
+
+        content {
+            includeModule("com.toasttab.canv", "can-i-use-anvil-processor")
+        }
+    }
+
+    mavenCentral()
+}
+
 dependencies {
     kapt("com.google.dagger:dagger-compiler:@DAGGER_VERSION@")
 }


### PR DESCRIPTION
This allows us to avoid the overhead of the plugin logic unless we're actually generating the report